### PR TITLE
Mark big-finish-downloader as EOL

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,0 +1,38 @@
+--- ./share/appdata/uk.et1.big-finish-downloader.metainfo.xml	2021-01-28 13:56:23.000000000 +0530
++++ ./share/appdata/uk.et1.big-finish-downloader.metainfo.xml	2024-08-06 07:31:36.762707302 +0530
+@@ -4,29 +4,28 @@
+   
+   <name>Big Finish Downloader</name>
+   <summary>A GTK app to download your Big Finish Collection</summary>
+-  
++  <developer_name>Peter Taylor</developer_name>
+   <metadata_license>MIT</metadata_license>
+   <project_license>MIT</project_license>
+-  <icon type="remote">https://raw.githubusercontent.com/Emersont1/big-finish-downloader/main/icons/tardis.svg</icon>
+   <description>
+     <p>
+       This is a program downloads your titles from the big finish website into a folder of your choosing
+     </p>
+   </description>
+   <content_rating type="oars-1.1" />
+-  <url type="homepage">https://github.com/Emersont1/big-finish-downloader</url>
++  <url type="homepage">https://github.com/flathub/uk.et1.big-finish-downloader</url>
+   <releases>
+     <release version="1.1.0.0" date="2021-01-28"/>
+     <release version="1.0.3.0" date="2021-01-25"/>
+     <release version="1.0.2.0" date="2021-01-25"/>
+     <release version="1.0.1.0" date="2021-01-24"/>
+     <release version="1.0.0.3" date="2021-01-15"/>
+-	</releases>
++  </releases>
+   
+   <launchable type="desktop-id">uk.et1.big-finish-downloader.desktop</launchable>
+   <screenshots>
+     <screenshot type="default">
+-      <image>https://raw.githubusercontent.com/Emersont1/big-finish-downloader/main/screenshots/main_window.png</image>
++      <image>https://raw.githubusercontent.com/flathub/uk.et1.big-finish-downloader/master/uk.png</image>
+     </screenshot>
+   </screenshots>
+-</component>
+\ No newline at end of file
++</component>

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
+    "end-of-life": "This application is no longer maintained.",
     "only-arches": ["x86_64"]
 }

--- a/uk.et1.big-finish-downloader.yaml
+++ b/uk.et1.big-finish-downloader.yaml
@@ -15,16 +15,18 @@ modules:
   - name: files
     buildsystem: simple
     build-commands:
-      - tar -xvf bin.tar.gz
       - cp -r bin /app
       - cp -r lib /app
       - cp -r share /app
       - ls /app/bin
       - chmod 755 /app/bin/big-finish-downloader-gtk
       - glib-compile-schemas /app/share/glib-2.0/schemas
+      - mkdir -p /app/share/icons/hicolor/scalable/apps/
+      - mv /app/share/icons/hicolor/128x128/apps/uk.et1.big-finish-downloader.svg /app/share/icons/hicolor/scalable/apps/
     sources:
-      - type: file
+      - type: archive
         url: https://github.com/flathub/uk.et1.big-finish-downloader/releases/download/v1.1.0/bin.tar.gz
         sha256: 4f4874613a66300c36989913210f7ead6cf31c50b1927f50fd0977d1d9e2d8fd
-      - type: file
+        strip-components: 0
+      - type: patch
         path: appdata.patch

--- a/uk.et1.big-finish-downloader.yaml
+++ b/uk.et1.big-finish-downloader.yaml
@@ -26,3 +26,5 @@ modules:
       - type: file
         url: https://github.com/flathub/uk.et1.big-finish-downloader/releases/download/v1.1.0/bin.tar.gz
         sha256: 4f4874613a66300c36989913210f7ead6cf31c50b1927f50fd0977d1d9e2d8fd
+      - type: file
+        path: appdata.patch

--- a/uk.et1.big-finish-downloader.yaml
+++ b/uk.et1.big-finish-downloader.yaml
@@ -24,5 +24,5 @@ modules:
       - glib-compile-schemas /app/share/glib-2.0/schemas
     sources:
       - type: file
-        url: https://github.com/Emersont1/big-finish-downloader/releases/download/v1.1.0/bin.tar.gz
+        url: https://github.com/flathub/uk.et1.big-finish-downloader/releases/download/v1.1.0/bin.tar.gz
         sha256: 4f4874613a66300c36989913210f7ead6cf31c50b1927f50fd0977d1d9e2d8fd


### PR DESCRIPTION
> This application is no longer maintained.

Source code repository seems to have been removed: https://github.com/Emersont1/big-finish-downloader